### PR TITLE
update 3dunet Dockerfile && add an overview version of README

### DIFF
--- a/MLPerf-based-workloads/3dunet/Dockerfile
+++ b/MLPerf-based-workloads/3dunet/Dockerfile
@@ -1,13 +1,28 @@
+# FaaS watchdog image
+FROM --platform=${TARGETPLATFORM:-linux/amd64}  ghcr.io/openfaas/of-watchdog:0.9.6 as watchdog
+# Base Image
 FROM tensorflow/tensorflow:2.2.0-gpu 
 RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub \
  && apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
 RUN apt-get update && apt-get install -y git
 
+WORKDIR /workspace
+COPY requirements.txt .
+RUN pip3 install --disable-pip-version-check -U -r requirements.txt
+
 ## Prepare src code 
 WORKDIR /workspace
-COPY . .
+COPY server server
 RUN git clone --recursive https://github.com/mlcommons/inference \
     && cd inference/vision/medical_imaging/3d-unet-kits19 \
     && git checkout r2.1 \
     && cp /workspace/server/* ./
-CMD ["/bin/bash"]
+
+## Setup FaaS components
+WORKDIR /workspace/inference/vision/medical_imaging/3d-unet-kits19
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
+ENV mode="http"
+ENV upstream_url="http://127.0.0.1:5000"
+ENV fprocess="python3 index.py"
+CMD ["fwatchdog"]

--- a/MLPerf-based-workloads/3dunet/requirements.txt
+++ b/MLPerf-based-workloads/3dunet/requirements.txt
@@ -1,0 +1,4 @@
+flask
+waitress
+numpy
+pillow

--- a/MLPerf-based-workloads/README.md
+++ b/MLPerf-based-workloads/README.md
@@ -1,0 +1,20 @@
+The building and testing instructions are described in each workload.
+
+The prebuilt images are:
+
+- `resnet`(vision/classification\_and\_detection): `yukiozhu/mlperf-faas-resnet:[pytorch/tensorflow/onnx]`
+- `3dunet`(vision/medical\_imaging/3d-unet-kits19): `yukiozhu/mlperf-faas-3dunet`
+- `retinanet`(vision/classification\_and\_detection): `yukiozhu/mlperf-faas-retinanet`
+- `bert`(language/bert): `yukiozhu/mlperf-faas-bert` 
+- `gnmt`(translation/gnmt): `yukiozhu/mlperf-faas-gnmt`
+- `rnnt`(speech\_recognition/rnnt): `yukiozhu/mlperf-faas-rnnt` 
+
+Note: the models should be already existed on the host, e.g. /models/3dunet/3dunet\_kits19\_128x128x128.tf. Please refer to the README instructions of each workload to download the models.
+
+Running examples:
+
+``` 
+docker run --network host -v /models/3dunet:/models/3dunet yukiozhu/mlperf-faas-3dunet
+cd faas-share-test/MLPerf-based-workloads/3dunet/client
+python3 httpclient.py --port 5000 --model_name 3dunet
+```


### PR DESCRIPTION
All the prebuilt image can be pulled from the docker hub directly now.